### PR TITLE
Fix linting issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,16 @@ ENV GNUPG_VERSION=2.2.40-1.1
 
 RUN apt-get update -y && \
   # Install necessary dependencies
-  apt-get install -y --no-install-recommends curl=${CURL_VERSION} lsb-release=${LSBRELEASE_VERSION} gnupg=${GNUPG_VERSION} && \
+  apt-get install -y --no-install-recommends \
+    curl=${CURL_VERSION} \
+    gnupg=${GNUPG_VERSION} \
+    lsb-release=${LSBRELEASE_VERSION} && \
   # Add Eclipse Adoptium public key
-  curl --proto "=https" -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc && \
+  curl --proto "=https" -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public \
+    | tee /etc/apt/keyrings/adoptium.asc && \
   # Add Eclipse Adoptium APT repository to the list of sources
-  echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list > /dev/null
+  echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" \
+    | tee /etc/apt/sources.list.d/adoptium.list > /dev/null
 
 
 # Final image


### PR DESCRIPTION
Split long RUN instructions into mulitple lines to make it easier to read and understand and sorts installed packages alphanumerically to improve maintainability.

Fixes https://rules.sonarsource.com/docker/RSPEC-7018/
Fixes https://rules.sonarsource.com/docker/RSPEC-7020/